### PR TITLE
Enlace a mi Perfil de GitHub

### DIFF
--- a/hello.md
+++ b/hello.md
@@ -3549,6 +3549,6 @@
 - hardynsnet
 - mpmerd
 - JeffAg96
-- AlvaTronsYT 
+- AlvaTronsYT
 - Ludeynis
-- JuanDGambaS
+- [JuanDGambaS](https://github.com/JuanDGambaS)


### PR DESCRIPTION
Se añade un enlace al perfil del usuario en tanto que hubo un problema de sincronización al aceptar otra Pull Request. Al parecer se removió el enlace de otro commit que estaba junto al principal de la Pull Request :D.